### PR TITLE
Enumerations empty by default

### DIFF
--- a/handlers/default-types.xsl
+++ b/handlers/default-types.xsl
@@ -86,7 +86,7 @@
 						<xsl:text>this.setAttribute("value", "</xsl:text><xsl:call-template name="get-duration-info"><xsl:with-param name="type">prefix</xsl:with-param><xsl:with-param name="pattern" select="$pattern" /></xsl:call-template>".concat(this.value).concat("<xsl:call-template name="get-duration-info"><xsl:with-param name="type">abbreviation</xsl:with-param><xsl:with-param name="pattern" select="$pattern" /></xsl:call-template><xsl:text>")); this.previousElementSibling.textContent = this.value;</xsl:text>
 					</xsl:when>
 					<xsl:otherwise> <!-- Use value if otherwise -->
-						<xsl:text>if (this.value) { this.setAttribute("value", this.value</xsl:text><xsl:if test="$whitespace = 'replace'">.replace(/\s/g, " ")</xsl:if><xsl:if test="$whitespace = 'collapse'">.replace(/\s+/g, " ").trim()</xsl:if><xsl:text>); } else { this.removeAttribute("value"); };</xsl:text>
+						<xsl:text>if (this.value) { this.setAttribute("value", escapeContent(this.value)</xsl:text><xsl:if test="$whitespace = 'replace'">.replace(/\s/g, " ")</xsl:if><xsl:if test="$whitespace = 'collapse'">.replace(/\s+/g, " ").trim()</xsl:if><xsl:text>); } else { this.removeAttribute("value"); };</xsl:text>
 					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:attribute>

--- a/handlers/enumerations.xsl
+++ b/handlers/enumerations.xsl
@@ -56,7 +56,7 @@
 				<xsl:value-of select="$type" />
 			</xsl:attribute>
 
-			<!-- add option to select no value in case of optional attribute -->
+			<!-- add option to select no value in case of no default or fixed value -->
 			<xsl:if test="$attribute = 'true' and not(@default) and not (@fixed)">
 				<xsl:element name="option">
 					<xsl:attribute name="value"/>

--- a/handlers/enumerations.xsl
+++ b/handlers/enumerations.xsl
@@ -3,25 +3,25 @@
 	version="3.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	
+
 	<xsl:template name="generate-select">
 		<xsl:param name="root-document" /> <!-- contains root document -->
 		<xsl:param name="root-path" /> <!-- contains path from root to included and imported documents -->
 		<xsl:param name="root-namespaces" /> <!-- contains root document's namespaces and prefixes -->
-		
+
 		<xsl:param name="namespace-documents" /> <!-- contains all documents in element namespace -->
-		
+
 		<xsl:param name="description" /> <!-- contains preferred description for element -->
 		<xsl:param name="type" /> <!-- contains primitive type -->
 		<xsl:param name="attribute" /> <!-- boolean indicating whether or not node is an attribute -->
 		<xsl:param name="multiple" /> <!-- boolean indicating whether or not generated element should be able to allow for multiple values -->
 		<xsl:param name="disabled" /> <!-- boolean indicating whether or not generated element should be disabled -->
-		
+
 		<xsl:element name="select">
 			<xsl:attribute name="onchange">
 				<xsl:text>this.childNodes.forEach(function(o) { if (o.nodeType == Node.ELEMENT_NODE) o.removeAttribute("selected"); }); this.children[this.selectedIndex].setAttribute("selected","selected");</xsl:text>
 			</xsl:attribute>
-			
+
 			<!-- attribute can have optional use=required values; normal elements are always required -->
 			<xsl:choose>
 				<xsl:when test="$attribute = 'true'">
@@ -33,42 +33,44 @@
 					<xsl:attribute name="required">required</xsl:attribute>
 				</xsl:otherwise>
 			</xsl:choose>
-			
+
 			<!-- disabled elements are used to omit invisible placeholders from inclusion in the validation and generated xml data -->
 			<xsl:if test="$disabled = 'true'">
 				<xsl:attribute name="disabled">disabled</xsl:attribute>
 			</xsl:if>
-			
+
 			<xsl:attribute name="data-xsd2html2xml-description">
 				<xsl:value-of select="$description" />
 			</xsl:attribute>
-			
+
 			<!-- <xsl:if test="not($invisible = 'true')">
 				<xsl:attribute name="data-xsd2html2xml-filled">true</xsl:attribute>
 			</xsl:if> -->
-			
+
 			<!-- add multiple keyword if several selections are allowed -->
 			<xsl:if test="$multiple = 'true'">
 				<xsl:attribute name="multiple">multiple</xsl:attribute>
 			</xsl:if>
-			
+
 			<xsl:attribute name="data-xsd2html2xml-primitive">
 				<xsl:value-of select="$type" />
 			</xsl:attribute>
-			
+
 			<!-- add option to select no value in case of optional attribute -->
-			<xsl:if test="$attribute = 'true' and @use = 'optional'">
-				<xsl:element name="option">-</xsl:element>
+			<xsl:if test="$attribute = 'true' and not(@default) and not (@fixed)">
+				<xsl:element name="option">
+					<xsl:attribute name="value"/>
+				</xsl:element>
 			</xsl:if>
-			
+
 			<!-- add options for each value; populate the element if there is corresponding data, or fill it with a fixed or default value -->
 			<xsl:call-template name="handle-enumerations">
 				<xsl:with-param name="root-document" select="$root-document" />
 				<xsl:with-param name="root-path" select="$root-path" />
 				<xsl:with-param name="root-namespaces" select="$root-namespaces" />
-				
+
 				<xsl:with-param name="namespace-documents" select="$namespace-documents" />
-				
+
 				<xsl:with-param name="default">
 					<xsl:choose>
 						<xsl:when test="@default"><xsl:value-of select="@default" /></xsl:when>
@@ -84,23 +86,23 @@
 			</xsl:call-template>
 		</xsl:element>
 	</xsl:template>
-	
+
 	<!-- Recursively searches for xs:enumeration elements and applies templates on them -->
 	<xsl:template name="handle-enumerations">
 		<xsl:param name="root-document" /> <!-- contains root document -->
 		<xsl:param name="root-path" /> <!-- contains path from root to included and imported documents -->
 		<xsl:param name="root-namespaces" /> <!-- contains root document's namespaces and prefixes -->
-		
+
 		<xsl:param name="namespace-documents" /> <!-- contains all documents in element namespace -->
-		
+
 		<xsl:param name="default" />
 		<xsl:param name="disabled">false</xsl:param>
-		
+
 		<xsl:apply-templates select=".//xs:restriction/xs:enumeration">
 			<xsl:with-param name="default" select="$default" />
 			<xsl:with-param name="disabled" select="$disabled" />
 		</xsl:apply-templates>
-		
+
 		<xsl:variable name="namespace">
 			<xsl:call-template name="get-namespace">
 				<xsl:with-param name="namespace-prefix">
@@ -111,22 +113,22 @@
 				</xsl:with-param>
 			</xsl:call-template>
 		</xsl:variable>
-		
+
 		<xsl:call-template name="forward">
 			<xsl:with-param name="stylesheet" select="$enumerations-stylesheet" />
 			<xsl:with-param name="template">handle-enumerations-forwardee</xsl:with-param>
-			
+
 			<xsl:with-param name="root-document" select="$root-document" />
 			<xsl:with-param name="root-path" select="$root-path" />
 			<xsl:with-param name="root-namespaces" select="$root-namespaces" />
-			
+
 			<xsl:with-param name="namespace-documents">
 				<xsl:choose>
 					<xsl:when test="(not($namespace-documents = '') and count($namespace-documents//document) > 0 and $namespace-documents//document[1]/@namespace = $namespace) or (contains(@type, ':') and starts-with(@type, $root-namespaces//root-namespace[@namespace = 'http://www.w3.org/2001/XMLSchema']/@prefix))">
 						<xsl:call-template name="inform">
 							<xsl:with-param name="message">Reusing loaded namespace documents</xsl:with-param>
 						</xsl:call-template>
-						
+
 						<xsl:copy-of select="$namespace-documents" />
 					</xsl:when>
 					<xsl:otherwise>
@@ -147,7 +149,7 @@
 					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:with-param>
-			
+
 			<xsl:with-param name="type-suffix">
 				<xsl:call-template name="get-suffix">
 					<xsl:with-param name="string" select="@type" />
@@ -157,34 +159,34 @@
 			<xsl:with-param name="disabled" select="$disabled" />
 		</xsl:call-template>
 	</xsl:template>
-	
+
 	<xsl:template name="handle-enumerations-forwardee" match="xsl:template[@name = 'handle-enumerations-forwardee']">
 		<xsl:param name="root-document" /> <!-- contains root document -->
 		<xsl:param name="root-path" /> <!-- contains path from root to included and imported documents -->
 		<xsl:param name="root-namespaces" /> <!-- contains root document's namespaces and prefixes -->
-		
+
 		<xsl:param name="namespace-documents" /> <!-- contains all documents in element namespace -->
-		
+
 		<xsl:param name="type-suffix" />
 		<xsl:param name="default" />
 		<xsl:param name="disabled" />
-		
+
 		<xsl:call-template name="log">
 			<xsl:with-param name="reference">handle-enumerations-forwardee</xsl:with-param>
 		</xsl:call-template>
-		
+
 		<xsl:for-each select="$namespace-documents//xs:simpleType[@name=$type-suffix]">
 			<xsl:call-template name="handle-enumerations">
 				<xsl:with-param name="root-document" select="$root-document" />
 				<xsl:with-param name="root-path" select="$root-path" />
 				<xsl:with-param name="root-namespaces" select="$root-namespaces" />
-				
+
 				<xsl:with-param name="namespace-documents" select="$namespace-documents" />
-				
+
 				<xsl:with-param name="default" select="$default" />
 				<xsl:with-param name="disabled" select="$disabled" />
 			</xsl:call-template>
 		</xsl:for-each>
 	</xsl:template>
-	
+
 </xsl:stylesheet>

--- a/js/html-populators.xsl
+++ b/js/html-populators.xsl
@@ -36,7 +36,7 @@
 								//check for input elements existing to handle empty elements
 								&amp;&amp; o.previousElementSibling.previousElementSibling.querySelector("input, textarea, select")
 								//check if element has been populated with data from an xml document
-								&amp;&amp; !o.previousElementSibling.previousElementSibling.querySelector("input, textarea, select").hasAttribute("data-xsd2html2xml-filled")) {
+								&amp;&amp; Array.from(o.previousElementSibling.previousElementSibling.querySelectorAll("input, textarea, select")).filter(function(el) {return el.hasAttribute("data-xsd2html2xml-filled")}).length == 0) {
 								clickRemoveButton(
 									o.parentElement.children[0].querySelector("legend &gt; button.remove, span &gt; button.remove")
 								);

--- a/js/html-populators.xsl
+++ b/js/html-populators.xsl
@@ -85,6 +85,9 @@
 						if (element.querySelector("input").getAttribute("data-xsd2html2xml-primitive") === "boolean") {
 							if (value === "true") {
 								element.querySelector("input").setAttribute("checked", "checked");
+							}
+							else if(value === "false" &amp;&amp; element.querySelector("input").hasAttribute("checked")) {
+								element.querySelector("input").removeAttribute("checked");
 							};
 						} else {
 							element.querySelector("input").setAttribute("value", value);

--- a/js/xml-generators.xsl
+++ b/js/xml-generators.xsl
@@ -116,7 +116,7 @@
 						            case "gyearmonth":
 						            	return node.getElementsByTagName("input")[0].getAttribute("value");
 						            default:
-						            	return node.getElementsByTagName("input")[0].value;
+						            	return escapeContent(node.getElementsByTagName("input")[0].value);
 				            	}
 				        }
 				    } else if (node.getElementsByTagName("select").length != 0) {
@@ -132,6 +132,22 @@
 				    } else if (node.getElementsByTagName("textarea").length != 0) {
 				    	return node.getElementsByTagName("textarea")[0].value;
 				    }
+				};
+
+				var characterToXmlSafe = {
+					"&lt;": "&amp;lt;",
+					"&gt;": "&amp;gt;",
+					"&amp;": "&amp;amp;",
+					"\&quot;": "&amp;quot;",
+					"&apos;": "&amp;apos;" /* This doesn't seem to work, so turned off in escapeContent function */
+				};
+
+				var escapeContent = function(content)
+				{
+					return content.replace(/[&lt;&gt;&amp;&quot;]/g, function(character)
+					{
+						return characterToXmlSafe[character];
+					});
 				}
 			</xsl:text>
 		</xsl:element>	


### PR DESCRIPTION
Furthering the fix to #23, an empty value is added to an HTML select element when there is no default or fixed value specified.

This doesn't alter the existing behaviour that attributes with `@use="optional"` provides an default, empty value

If there is no `@use`, `@default` or `@fixed` attributes a default, empty value is provided (this is a change)

If `@use="required"` is specified a default, empty value is _still_ provided, so that the user has to make an informed choice, rather than the first item in the list being pre-selected and possibly submitted without even thinking about it. If the user tries to submit the form without chosing a valid (non-empty) selection then the HTML validation will complain.

If `@default` or `@fixed` is provided, no empty value will be provided. I think this is definitely correct for `@fixed`, but `@default` could be argued that we should allow an empty value, but it shouldn't be the default. I did test this, but it is not what I am submitting because in my case my XML processor (that handles the submitted form) adds omitted attributes with their default value anyway. I don't mind adding this (a blank option when `@default` is set) if you think it is incorrect though.